### PR TITLE
SM-29-User-profile-table

### DIFF
--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -1,21 +1,25 @@
 module.exports = (sequelize, DataTypes) => {
-    /*Define user profile table*/
+    /* Define user profile table */
     const Profile = sequelize.define("Profile", {
-        username: {
-            type: DataTypes.STRING,
-            allowNull: false
-        },
-        alergies: {
-            type: DataTypes.STRING,
-            allowNull: false
-        },
-        email: {
-            type: DataTypes.STRING,
+        allergies: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
             allowNull: false,
-            unique: true
+            defaultValue: []
+        },
+        preferences: {
+            type: DataTypes.ARRAY(DataTypes.STRING),
+            allowNull: false,
+            defaultValue: []
         }
-        //may add more once we figure out our APIs
     });
+
+    Profile.associate = (models) => {
+        // Define a one-to-one association between Users and Profile
+        Profile.belongsTo(models.Users, {
+            foreignKey: 'userId',
+            onDelete: 'cascade'
+        });
+    };
 
     return Profile;
 }

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -4,7 +4,7 @@ module.exports = (sequelize, DataTypes) => {
         allergies: {
             type: DataTypes.ARRAY(DataTypes.STRING),
             allowNull: false,
-            defaultValue: []
+            defaultValue: [] //Set default value as empty array
         },
         preferences: {
             type: DataTypes.ARRAY(DataTypes.STRING),
@@ -16,7 +16,7 @@ module.exports = (sequelize, DataTypes) => {
     Profile.associate = (models) => {
         // Define a one-to-one association between Users and Profile
         Profile.belongsTo(models.Users, {
-            foreignKey: 'userId',
+            foreignKey: 'UserId',
             onDelete: 'cascade'
         });
     };

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -1,0 +1,21 @@
+module.exports = (sequelize, DataTypes) => {
+    /*Define user profile table*/
+    const Profile = sequelize.define("Profile", {
+        username: {
+            type: DataTypes.STRING,
+            allowNull: false
+        },
+        alergies: {
+            type: DataTypes.STRING,
+            allowNull: false
+        },
+        email: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            unique: true
+        }
+        //may add more once we figure out our APIs
+    });
+
+    return Profile;
+}

--- a/server/models/Users.js
+++ b/server/models/Users.js
@@ -20,6 +20,9 @@ module.exports = (sequelize, DataTypes) => {
         Users.hasOne(models.Inventory, {
             onDelete: 'cascade'
         });
+        Users.hasOne(models.Profile, {
+            onDelete: 'cascade'
+        })
     };
 
     return Users


### PR DESCRIPTION
To store allergies and preferences as arrays of strings, the data types were updated to use DataTypes.ARRAY(DataTypes.STRING). This adjustment signifies that the columns will now contain arrays of string values.

A one-to-one association was introduced to establish a relationship between users and their profiles, enabling us to navigate from users to profiles and vice versa.

    Profile.associate = (models) => {
        // Define a one-to-one association between Users and Profile
        Profile.belongsTo(models.Users, {
            foreignKey: 'UserId',
            onDelete: 'cascade'
        });
    };

The 'UserId' in the profiles table matches the primary key in the users table, so now we can navigate between the two tables conveniently.

While it's technically fine to define the relationship in 'Users.js' only, it's usually a good idea to do it in both models. This way, you can access user info from the profile's point of view and vice versa, this way the profiles can have access to its user's info like email and username.