### PR TITLE
SM-53-Initialize-meal-data

### DIFF
--- a/server/controllers/Recipes.js
+++ b/server/controllers/Recipes.js
@@ -2,9 +2,9 @@ const { Recipes } = require('../models');
 
 const fillRecipes = async (req, res) => {
     let searchByFirstLetter = ['a', 'b', 'c', 'd',
-        'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
-        'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];
-    for (let j = 0; j < 26; j++) {
+        'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
+        'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];
+    for (let j = 0; j < searchByFirstLetter.length; j++) {
         try {
             const mealDbResponse = await fetch(`https://www.themealdb.com/api/json/v1/1/search.php?f=${searchByFirstLetter[j]}`);
 

--- a/server/controllers/Recipes.js
+++ b/server/controllers/Recipes.js
@@ -1,0 +1,63 @@
+const { Recipes } = require('../models');
+
+const fillRecipes = async (req, res) => {
+    let searchByFirstLetter = ['a', 'b', 'c', 'd',
+        'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+        'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];
+    for (let j = 0; j < 26; j++) {
+        try {
+            const mealDbResponse = await fetch(`https://www.themealdb.com/api/json/v1/1/search.php?f=${searchByFirstLetter[j]}`);
+
+            if (!mealDbResponse.ok) {
+                res.status(400);
+                return res.json({ error: 'Failed to fetch from TheMealDB' });
+            }
+
+            const data = await mealDbResponse.json();
+            const meals = data.meals;
+            meals && await meals.forEach(async meal => {
+                const ingredients = [];
+                const measurements = [];
+                for (let i = 1; i <= 20; i++) {
+                    const ingredientKey = `strIngredient${i}`;
+                    const measurementKey = `strMeasure${i}`;
+                    if (meal[ingredientKey] && meal[ingredientKey] !== "") {
+                        ingredients.push(meal[ingredientKey]);
+                        measurements.push(meal[measurementKey]);
+                    };
+                }
+                try {
+                    const possibleDuplicate = await Recipes.findOne({
+                        where: {
+                            name: meal.strMeal
+                        }
+                    })
+
+                    !possibleDuplicate && await Recipes.create({
+                        name: meal.strMeal,
+                        ingredients: ingredients,
+                        measurements: measurements,
+                        instructions: meal.strInstructions,
+                        thumbnail: meal.strMealThumb,
+                        category: meal.strCategory,
+                        area: meal.strArea
+                    })
+
+                } catch (error) {
+                    console.log("Error adding recipe: ", error);
+                }
+            });
+        } catch (error) {
+            console.log('Failed to add recipes from TheMealDB: ', error);
+            res.status(400);
+            return res.json({ error: 'Error adding recipes' })
+        }
+    }
+
+    res.status(200);
+    return res.json('Successfully filled table');
+}
+
+module.exports = {
+    fillRecipes
+}

--- a/server/index.js
+++ b/server/index.js
@@ -27,9 +27,12 @@ app.use(cors({
 const userRouter = require('./routes/Users');
 const inventoryRouter = require('./routes/Inventory');
 const profileRouter = require('./routes/Profile');
+const recipeRouter = require('./routes/Recipes');
 app.use('/user', userRouter);
 app.use('/inventory', inventoryRouter);
 app.use('/profile', profileRouter);
+app.use('/recipes', recipeRouter);
+
 
 db.sequelize.sync().then(() => {
     app.listen(3001, () => {

--- a/server/models/Recipes.js
+++ b/server/models/Recipes.js
@@ -16,12 +16,23 @@ module.exports = (sequelize, DataTypes) => {
             defaultValue: []
         },
         instructions: {
-            type: DataTypes.STRING,
-            allowNull: false
+            type: DataTypes.TEXT,
+            allowNull: false,
+            validate: {
+                len: [0, 6000]
+            }
         },
         thumbnail: {
             type: DataTypes.STRING,
             allowNull: false
+        },
+        category: {
+            type: DataTypes.STRING,
+            allowNull: true
+        },
+        area: {
+            type: DataTypes.STRING,
+            allowNull: true
         }
     });
 

--- a/server/routes/Recipes.js
+++ b/server/routes/Recipes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { fillRecipes } = require('../controllers/Recipes');
+const router = express.Router();
+
+router.post('/fill', fillRecipes);
+
+
+module.exports = router;

--- a/server/test/recipes.test.js
+++ b/server/test/recipes.test.js
@@ -1,0 +1,56 @@
+const { fillRecipes } = require('../controllers/Recipes');
+const { Recipes } = require('../models');
+
+jest.mock('../models')
+
+const res = {
+    status: jest.fn((x) => x),
+    json: jest.fn((x) => x)
+};
+
+global.fetch = jest.fn();
+
+/*test fillRecipes*/
+describe('On failure to fill recipes', () => {
+    it('should handle error when failing to fetch', async () => {
+        global.fetch = jest.fn(() => Promise.reject('Fetch error'));
+
+        const req = {};
+
+        await fillRecipes(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Error adding recipes' });
+    });
+})
+
+describe('On successful fill recipes', () => {
+    it('should fill recipes', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({ meals: [{ strMeal: 'Test Meal' }] }),
+            })
+        );
+
+        const req = {};
+        const fakeMeal = {
+            name: 'Test Meal',
+            ingredients: [],
+            measurements: [],
+            instructions: "Instructions",
+            thumbnail: 'Thumbnail',
+            category: 'Category',
+            area: 'Area'
+        }
+
+        jest.spyOn(Recipes, 'findOne').mockResolvedValue(fakeMeal); // Mock finding a meal that hasnt been created
+        jest.spyOn(Recipes, 'create').mockResolvedValue(fakeMeal); // Mock creating meal
+        jest.spyOn(Recipes, 'findOne').mockResolvedValue(fakeMeal); // Mock finding meal thats been created
+
+        await fillRecipes(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith('Successfully filled table');
+    });
+})

--- a/server/test/recipes.test.js
+++ b/server/test/recipes.test.js
@@ -44,9 +44,35 @@ describe('On successful fill recipes', () => {
             area: 'Area'
         }
 
-        jest.spyOn(Recipes, 'findOne').mockResolvedValue(fakeMeal); // Mock finding a meal that hasnt been created
+        jest.spyOn(Recipes, 'findOne').mockResolvedValue(null); // Mock not finding a duplicate meal
         jest.spyOn(Recipes, 'create').mockResolvedValue(fakeMeal); // Mock creating meal
-        jest.spyOn(Recipes, 'findOne').mockResolvedValue(fakeMeal); // Mock finding meal thats been created
+
+        await fillRecipes(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith('Successfully filled table');
+    });
+
+    it('should avoid creating duplicate recipes', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({ meals: [{ strMeal: 'Test Meal' }] }),
+            })
+        );
+
+        const req = {};
+        const fakeMeal = {
+            name: 'Test Meal',
+            ingredients: [],
+            measurements: [],
+            instructions: "Instructions",
+            thumbnail: 'Thumbnail',
+            category: 'Category',
+            area: 'Area'
+        }
+
+        jest.spyOn(Recipes, 'findOne').mockResolvedValue(fakeMeal); // Mock finding a duplicate meal
 
         await fillRecipes(req, res);
 


### PR DESCRIPTION
Created route for recipes and created an endpoint for filling up the recipes table with recipes from TheMealDB. 

Main Notes:
- TheMealDb has no endpoint that gives the entire list of meals. The closest thing it has it getting all meals that start with a certain letter. My solution was to get that list for every letter of the alphabet, this worked and I successfully got every meal from the api into our database. Furthermore there is no harm in calling the method more than once since it only adds a meal to the database if it doesn't already exist. 
- Made some changes to the recipes model, each recipe has a category and an area so i added those as columns in the table. These will be important for querying the table based on the user's preferences. 
- Lastly, wrote a couple unit tests to test the fillRecipes method. Please let me know if you have any suggestions for any other test cases you think the method might need. 