### PR TITLE
SM-68-Changed-user-info-retrieval

### DIFF
--- a/front-end/src/component/Dashboard/Dashboard.js
+++ b/front-end/src/component/Dashboard/Dashboard.js
@@ -1,43 +1,10 @@
-import { React, useEffect, useContext } from 'react'
-import endPoints from '../../config/fetch.js'
+import { React } from 'react'
 import NavigationBar from '../NavigationBar.js';
 import Dashboardbody from './Dashboardbody.js';
 import DashboardFooter from '../DashboardFooter.js';
-import UserInfo from '../../config/UserInfo.js';
 import '../../styles/Dashboard.css'
 
 const Dashboard = () => {
-    const { setUserInformation } = useContext(UserInfo);
-
-    useEffect(() => {
-        const findUserInfo = async () => {
-            try {
-                const response = await fetch(endPoints.loginEndpoint, {
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    credentials: 'include' // Include credentials in the request to allow browser to send cookies
-                });
-
-                if (response.ok) {
-                    const userData = await response.json();
-                    setUserInformation({
-                        username: userData.username,
-                        email: userData.email,
-                        id: userData.id
-                    });
-                };
-            }
-            catch (error) {
-                return;
-            }
-        };
-        findUserInfo();
-    },
-        []
-    );
-
     return (
         <div >
             <NavigationBar />

--- a/front-end/src/component/user/Login/Login.js
+++ b/front-end/src/component/user/Login/Login.js
@@ -8,7 +8,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import '../../../styles/Login.css'
 
 const Login = () => {
-    const { setStatus } = useContext(UserInfo);
+    const { setStatus, setUserInformation } = useContext(UserInfo);
     const navigate = useNavigate();
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
@@ -46,9 +46,14 @@ const Login = () => {
 
             if (res.ok) {
                 const responseData = await res.json();
-                console.log('Response data:', responseData);
+                console.log('Response data:', responseData.status);
+                setUserInformation({
+                    username: responseData.username,
+                    email: responseData.email,
+                    id: responseData.id
+                });
                 Swal.fire({
-                    title: `${responseData}`,
+                    title: `${responseData.status}`,
                     icon: "success"
                 });
                 setTimeout(() => {

--- a/server/controllers/Users.js
+++ b/server/controllers/Users.js
@@ -71,7 +71,12 @@ const userLogin = async (req, res) => {
     req.session.authorized = true;//sets the user as authorized
 
     res.status(200);
-    return res.json("Login successful");
+    res.json({
+        status: "Login successful",
+        username: userExists.username,
+        email: userExists.email,
+        id: userExists.id
+    });
 };
 
 const Logout = async (req, res) => {

--- a/server/test/login.test.js
+++ b/server/test/login.test.js
@@ -74,16 +74,16 @@ describe('On successful user', () => {
         };
 
         // Mock the Users.findOne function to return a user object
-        jest.spyOn(Users, 'findOne').mockResolvedValue({ email: "powers@gmail.com", password: "hashedPassword" });
+        jest.spyOn(Users, 'findOne').mockResolvedValue({ email: "powers@gmail.com", password: "hashedPassword", id: Number.MAX_SAFE_INTEGER });
 
         // Mock the bcrypt.compare function to return true, indicating correct password
         jest.spyOn(bcrypt, 'compare').mockResolvedValue(true);
 
         await userLogin(req, res);
         expect(res.status).toHaveBeenCalledWith(200);
-        expect(res.json).toHaveBeenCalledWith("Login successful");
+        expect(res.json).toHaveBeenCalledWith({ status: "Login successful", email: "powers@gmail.com", id: Number.MAX_SAFE_INTEGER });
 
-        expect(req.session.user).toEqual({ email: "powers@gmail.com", password: "hashedPassword" });
+        expect(req.session.user).toEqual({ email: "powers@gmail.com", password: "hashedPassword", id: Number.MAX_SAFE_INTEGER });
         expect(req.session.authorized).toBe(true);
     });
 });


### PR DESCRIPTION
Instead of getting the user information from the cookie header, we will now return the user information when the user hits the login endpoint. This is our alternative because render does not allow us to send cookies unless we have a custom domain.